### PR TITLE
Add a click action to toggle rules from the authority display

### DIFF
--- a/src/main/java/xyz/nucleoid/leukocyte/command/ProtectCommand.java
+++ b/src/main/java/xyz/nucleoid/leukocyte/command/ProtectCommand.java
@@ -352,7 +352,7 @@ public final class ProtectCommand {
         text = text.append(" Shapes:\n").append(authority.shapes.displayList());
 
         if (!authority.rules.isEmpty()) {
-            text.append(" Rules:\n").append(authority.rules.display());
+            text.append(" Rules:\n").append(authority.rules.clickableDisplay(authority));
         }
 
         context.getSource().sendFeedback(text, false);

--- a/src/main/java/xyz/nucleoid/leukocyte/rule/ProtectionRuleMap.java
+++ b/src/main/java/xyz/nucleoid/leukocyte/rule/ProtectionRuleMap.java
@@ -5,6 +5,8 @@ import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.MutableText;
 import net.minecraft.util.Formatting;
+import xyz.nucleoid.leukocyte.authority.Authority;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
@@ -48,7 +50,22 @@ public final class ProtectionRuleMap {
             RuleResult result = entry.getValue();
 
             text = text.append("  ").append(new LiteralText(rule.getKey()).formatted(Formatting.GRAY))
-                    .append(" = ").append(new LiteralText(result.getKey()).formatted(result.getFormatting()))
+                    .append(" = ").append(result.display())
+                    .append("\n");
+        }
+
+        return text;
+    }
+
+    public MutableText clickableDisplay(Authority authority) {
+        MutableText text = new LiteralText("");
+
+        for (Map.Entry<ProtectionRule, RuleResult> entry : this.map.entrySet()) {
+            ProtectionRule rule = entry.getKey();
+            RuleResult result = entry.getValue();
+
+            text = text.append("  ").append(new LiteralText(rule.getKey()).formatted(Formatting.GRAY))
+                    .append(" = ").append(result.clickableDisplay(authority, rule))
                     .append("\n");
         }
 

--- a/src/main/java/xyz/nucleoid/leukocyte/rule/RuleResult.java
+++ b/src/main/java/xyz/nucleoid/leukocyte/rule/RuleResult.java
@@ -2,7 +2,13 @@ package xyz.nucleoid.leukocyte.rule;
 
 import com.mojang.serialization.Codec;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import xyz.nucleoid.leukocyte.authority.Authority;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -39,6 +45,30 @@ public enum RuleResult {
 
     public Formatting getFormatting() {
         return this.formatting;
+    }
+
+    public MutableText display() {
+        return new LiteralText(this.key).formatted(this.formatting);
+    }
+
+    public MutableText clickableDisplay(Authority authority, ProtectionRule rule) {
+        if (!this.isDefinitive()) {
+            return this.display();
+        }
+
+        String command = "/protect set rule " + authority.key + " " + rule.getKey() + " " + this.getOpposite().key;
+        ClickEvent clickEvent = new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, command);
+
+        return this.display().styled(style -> style.withClickEvent(clickEvent));
+    }
+
+    public RuleResult getOpposite() {
+        switch (this) {
+            case ALLOW: return RuleResult.DENY;
+            case DENY: return RuleResult.ALLOW;
+            case PASS:
+            default: return null;
+        }
     }
 
     public boolean isDefinitive() {


### PR DESCRIPTION
This pull request allows users to click the 'deny' and 'allow' text in the authority display to suggest a command which toggles the respective rule for that authority.

![](https://user-images.githubusercontent.com/24855774/109690469-606a9880-7b54-11eb-80c3-d6f6b04626ab.png)
