### PR TITLE
Fixed compatibility with Player Roles 1.3.1 and implemented refactors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
   modImplementation include('xyz.nucleoid:stimuli:0.1.0')
 
-  modCompileOnly "dev.gegy:player-roles:1.2.0"
+  modCompileOnly "dev.gegy:player-roles:1.3.1"
 
   modRuntime("com.github.SuperCoder7979:databreaker:0.2.6") {
     exclude module: "fabric-loader"

--- a/src/main/java/xyz/nucleoid/leukocyte/roles/RoleAccessor.java
+++ b/src/main/java/xyz/nucleoid/leukocyte/roles/RoleAccessor.java
@@ -1,15 +1,15 @@
 package xyz.nucleoid.leukocyte.roles;
 
 import dev.gegy.roles.Role;
-import dev.gegy.roles.RoleConfiguration;
-import dev.gegy.roles.api.HasRoles;
+import dev.gegy.roles.PlayerRolesConfig;
+import dev.gegy.roles.api.RoleOwner;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.server.network.ServerPlayerEntity;
 
 import java.util.stream.Stream;
 
 public interface RoleAccessor {
-    RoleAccessor INSTANCE = FabricLoader.getInstance().isModLoaded("player-roles") ? new PlayerRoles() : new None();
+    RoleAccessor INSTANCE = FabricLoader.getInstance().isModLoaded("player_roles") ? new PlayerRoles() : new None();
 
     Stream<String> getAllRoles();
 
@@ -43,7 +43,7 @@ public interface RoleAccessor {
 
         @Override
         public Stream<String> getAllRoles() {
-            RoleConfiguration roles = RoleConfiguration.get();
+            PlayerRolesConfig roles = PlayerRolesConfig.get();
             return Stream.concat(
                     roles.stream(),
                     Stream.of(roles.everyone())
@@ -52,16 +52,16 @@ public interface RoleAccessor {
 
         @Override
         public Stream<String> getRolesFor(ServerPlayerEntity player) {
-            if (player instanceof HasRoles) {
-                return ((HasRoles) player).getRoles().stream().map(Role::getName);
+            if (player instanceof RoleOwner) {
+                return ((RoleOwner) player).getRoles().stream().map(Role::getName);
             }
             return Stream.empty();
         }
 
         @Override
         public boolean hasRole(ServerPlayerEntity player, String role) {
-            if (player instanceof HasRoles) {
-                return ((HasRoles) player).getRoles().hasRole(role);
+            if (player instanceof RoleOwner) {
+                return ((RoleOwner) player).getRoles().hasRole(role);
             }
             return false;
         }


### PR DESCRIPTION
Current compiled Player Roles version (1.2.0) is outdated and some refactors happened in between versions.
This PR aims to fix these incompatibilities with the latest version of Player Roles available in 1.16.5.

The main issue was the inability to exclude roles from authorities, as the `RoleAccessor INSTANCE` was always returning the None() class as `isModLoaded("player-roles")` was wrong due to the wrong mod ID being used.

Several other refactors had to be done to match the mismatch with methods and classes in 1.3.1.

Tested on a 1.16.5 server, the `RoleAccessor instance` is now returning the correct class and the mod player_roles is successfully marked as loaded if present on the server.