### PR TITLE
Add the modify flower pots rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Leukocyte provides various rules that can be applied within authorities. These r
  - `pickup_items` controls whether items can be picked up by players or other entities
  - `unstable_tnt` controls tnt automatically igniting when placed
  - `ignite_tnt` controls whether tnt can be ignited
+ - `modify_flower_pots` controls whether plants can be placed in or removed from flower pots
  - `firework_explode` controls whether fireworks can explode instead of only fizzling out
  - `dispenser_activate` controls whether dispensers and droppers can be activated
  - `spawn_withers` controls whether withers can be summoned

--- a/src/main/java/xyz/nucleoid/leukocyte/rule/ProtectionRule.java
+++ b/src/main/java/xyz/nucleoid/leukocyte/rule/ProtectionRule.java
@@ -39,6 +39,7 @@ public final class ProtectionRule {
 
     public static final ProtectionRule UNSTABLE_TNT = register("unstable_tnt");
     public static final ProtectionRule IGNITE_TNT = register("ignite_tnt");
+    public static final ProtectionRule MODIFY_FLOWER_POTS = register("modify_flower_pots");
     public static final ProtectionRule FIREWORK_EXPLODE = register("firework_explode");
     public static final ProtectionRule DISPENSER_ACTIVATE = register("dispenser_activate");
     public static final ProtectionRule SPAWN_WITHER = register("spawn_wither");

--- a/src/main/java/xyz/nucleoid/leukocyte/rule/enforcer/LeukocyteRuleEnforcer.java
+++ b/src/main/java/xyz/nucleoid/leukocyte/rule/enforcer/LeukocyteRuleEnforcer.java
@@ -22,6 +22,7 @@ import xyz.nucleoid.stimuli.event.block.BlockRandomTickEvent;
 import xyz.nucleoid.stimuli.event.block.BlockUseEvent;
 import xyz.nucleoid.stimuli.event.block.CoralDeathEvent;
 import xyz.nucleoid.stimuli.event.block.DispenserActivateEvent;
+import xyz.nucleoid.stimuli.event.block.FlowerPotModifyEvent;
 import xyz.nucleoid.stimuli.event.block.FluidRandomTickEvent;
 import xyz.nucleoid.stimuli.event.entity.EntityShearEvent;
 import xyz.nucleoid.stimuli.event.entity.EntitySpawnEvent;
@@ -183,6 +184,9 @@ public final class LeukocyteRuleEnforcer implements ProtectionRuleEnforcer {
 
         this.forRule(events, rules.test(ProtectionRule.IGNITE_TNT))
                 .applySimple(TntIgniteEvent.EVENT, rule -> (world, pos, igniter) -> rule);
+
+        this.forRule(events, rules.test(ProtectionRule.MODIFY_FLOWER_POTS))
+                .applySimple(FlowerPotModifyEvent.EVENT, rule -> (player, hand, hitResult) -> rule);
 
         this.forRule(events, rules.test(ProtectionRule.FIREWORK_EXPLODE))
                 .applySimple(FireworkExplodeEvent.EVENT, rule -> firework -> rule);


### PR DESCRIPTION
This pull request adds a new `modify_flower_pots` protection rule, which should end lobby griefing by removing plants from flower pots:

<img width="629" alt="Example of plants missing from various flower pots within a lush lobby area" src="https://github.com/NucleoidMC/leukocyte/assets/24855774/4daeea07-234b-4bd5-a140-d5201ade8ca8">