### PR TITLE
Update mod to Minecraft 1.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'fabric-loom' version '1.6.+'
+  id 'fabric-loom' version '1.7.+'
   id "com.modrinth.minotaur" version "2.+"
 }
 import com.modrinth.minotaur.TaskModrinthUpload
@@ -12,7 +12,6 @@ repositories {
   maven { url = "https://maven.nucleoid.xyz" }
   maven { url = "https://maven.gegy.dev/" }
   maven { url = "https://jitpack.io" }
-  maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 }
 
 dependencies {
@@ -22,10 +21,10 @@ dependencies {
 
   modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-  modImplementation include('xyz.nucleoid:stimuli:0.4.11+1.20.6')
+  modImplementation include('xyz.nucleoid:stimuli:0.4.12+1.21')
 
-  modCompileOnly "dev.gegy:player-roles-api:1.6.8"
-  modCompileOnly "me.lucko:fabric-permissions-api:0.2-SNAPSHOT"
+  modCompileOnly "dev.gegy:player-roles-api:1.6.11"
+  modCompileOnly "me.lucko:fabric-permissions-api:0.3.1"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-minecraft_version=1.20.6
-yarn_mappings=1.20.6+build.1
+minecraft_version=1.21
+yarn_mappings=1.21+build.2
 loader_version=0.15.11
 
 #Dependencies
-fabric_version=0.98.0+1.20.6
+fabric_version=0.100.3+1.21
 
 # Mod Properties
 mod_version=0.3.8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -55,7 +55,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,7 +14,7 @@
   "depends": {
     "fabricloader": ">=0.12",
     "fabric": "*",
-    "minecraft": ">=1.20.5-",
+    "minecraft": ">=1.21-",
     "stimuli": ">=0.4.3",
     "java": ">=21"
   }


### PR DESCRIPTION
This pull request updates the mod to Minecraft 1.21 by updating dependencies. In particular, Stimuli, which is bundled within this mod, was updated to a version that supports Minecraft 1.21.