### PR TITLE
Update mod to Minecraft 1.21.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,10 @@ dependencies {
 
   modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-  modImplementation include('xyz.nucleoid:stimuli:0.5.0+1.21.5')
+  modImplementation include("xyz.nucleoid:stimuli:${project.stimuli_version}")
 
-  modCompileOnly "dev.gegy:player-roles-api:1.6.13"
-  modCompileOnly "me.lucko:fabric-permissions-api:0.3.3"
+  modCompileOnly "dev.gegy:player-roles-api:${project.player_roles_version}"
+  modCompileOnly "me.lucko:fabric-permissions-api:${project.permission_api_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,15 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-minecraft_version=1.21.5
-yarn_mappings=1.21.5+build.1
-loader_version=0.16.13
+minecraft_version=1.21.6
+yarn_mappings=1.21.6+build.1
+loader_version=0.16.14
 
 #Dependencies
-fabric_version=0.120.0+1.21.5
+fabric_version=0.127.1+1.21.6
+stimuli_version=0.5.1+1.21.6
+player_roles_version=1.6.14
+permission_api_version=0.4.0
 
 # Mod Properties
 mod_version=0.3.12

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,7 +14,7 @@
   "depends": {
     "fabricloader": ">=0.12",
     "fabric": "*",
-    "minecraft": ">=1.21.5-",
+    "minecraft": ">=1.21.6-",
     "stimuli": ">=0.4.3",
     "java": ">=21"
   }


### PR DESCRIPTION
Leukocyte itself does not break with Minecraft 1.21.6, but the bundled Stimuli dependency does.