### PR TITLE
Update mod to Minecraft 1.21.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-minecraft_version=1.21.7
-yarn_mappings=1.21.7+build.1
-loader_version=0.16.14
+minecraft_version=1.21.8
+yarn_mappings=1.21.8+build.1
+loader_version=0.17.2
 
 #Dependencies
-fabric_version=0.127.1+1.21.6
-stimuli_version=0.5.1+1.21.6
-player_roles_version=1.6.14
+fabric_version=0.133.0+1.21.8
+stimuli_version=0.5.2+1.21.8
+player_roles_version=1.6.15
 permission_api_version=0.4.0
 
 # Mod Properties


### PR DESCRIPTION
This pull request changes the compilation target to Minecraft 1.21.8, although the mod and its bundled Stimuli dependency still are compatible with Minecraft 1.21.6 and 1.21.7.