### PR TITLE
Update to 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'fabric-loom' version '1.11.+'
+  id 'fabric-loom' version '1.13.+'
   id "com.modrinth.minotaur" version "2.+"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,15 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-minecraft_version=1.21.9
-yarn_mappings=1.21.9+build.1
-loader_version=0.17.2
+minecraft_version=1.21.11
+yarn_mappings=1.21.11+build.3
+loader_version=0.18.2
 
 #Dependencies
-fabric_version=0.134.0+1.21.9
-stimuli_version=0.5.3+1.21.9
+fabric_version=0.139.5+1.21.11
+stimuli_version=0.5.4+1.21.11
 player_roles_version=1.6.15
-permission_api_version=0.5.0
+permission_api_version=0.6.1
 
 # Mod Properties
 mod_version=0.3.14

--- a/src/main/java/xyz/nucleoid/leukocyte/command/ProtectCommand.java
+++ b/src/main/java/xyz/nucleoid/leukocyte/command/ProtectCommand.java
@@ -12,6 +12,7 @@ import net.minecraft.command.argument.BlockPosArgumentType;
 import net.minecraft.command.argument.DimensionArgumentType;
 import net.minecraft.command.argument.EntityArgumentType;
 import net.minecraft.command.argument.GameProfileArgumentType;
+import net.minecraft.command.permission.PermissionLevel;
 import net.minecraft.entity.Entity;
 import net.minecraft.screen.ScreenTexts;
 import net.minecraft.server.command.ServerCommandSource;
@@ -47,7 +48,7 @@ public final class ProtectCommand {
         // @formatter:off
         dispatcher.register(
             literal("protect")
-                .requires(source -> PermissionAccessor.INSTANCE.hasPermission(source, "leukocyte.commands", 4))
+                .requires(source -> PermissionAccessor.INSTANCE.hasPermission(source, "leukocyte.commands", PermissionLevel.OWNERS))
                 .then(literal("add")
                     .then(argument("authority", StringArgumentType.string())
                     .executes(ProtectCommand::addAuthority)

--- a/src/main/java/xyz/nucleoid/leukocyte/command/ShapeCommand.java
+++ b/src/main/java/xyz/nucleoid/leukocyte/command/ShapeCommand.java
@@ -9,6 +9,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import net.minecraft.command.argument.BlockPosArgumentType;
 import net.minecraft.command.argument.DimensionArgumentType;
+import net.minecraft.command.permission.PermissionLevel;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
@@ -38,7 +39,7 @@ public final class ShapeCommand {
         // @formatter:off
         dispatcher.register(
             literal("protect")
-                .requires(source -> PermissionAccessor.INSTANCE.hasPermission(source, "leukocyte.commands", 4))
+                .requires(source -> PermissionAccessor.INSTANCE.hasPermission(source, "leukocyte.commands", PermissionLevel.OWNERS))
                 .then(literal("shape")
                     .then(literal("start").executes(ShapeCommand::startShape))
                     .then(literal("stop").executes(ShapeCommand::stopShape))

--- a/src/main/java/xyz/nucleoid/leukocyte/roles/PermissionAccessor.java
+++ b/src/main/java/xyz/nucleoid/leukocyte/roles/PermissionAccessor.java
@@ -2,15 +2,18 @@ package xyz.nucleoid.leukocyte.roles;
 
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.command.permission.Permission;
+import net.minecraft.command.permission.PermissionLevel;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
+import org.jetbrains.annotations.NotNull;
 
 public interface PermissionAccessor {
     PermissionAccessor INSTANCE = FabricLoader.getInstance().isModLoaded("fabric-permissions-api-v0") ? new FabricPermissionsV0() : new None();
 
     boolean hasPermission(ServerPlayerEntity player, String permission);
 
-    boolean hasPermission(ServerCommandSource source, String permission, int opLevel);
+    boolean hasPermission(ServerCommandSource source, String permission, @NotNull PermissionLevel opLevel);
 
     final class None implements PermissionAccessor {
         None() {
@@ -22,8 +25,8 @@ public interface PermissionAccessor {
         }
 
         @Override
-        public boolean hasPermission(ServerCommandSource source, String permission, int opLevel) {
-            return source.hasPermissionLevel(opLevel);
+        public boolean hasPermission(ServerCommandSource source, String permission, @NotNull PermissionLevel opLevel) {
+            return source.getPermissions().hasPermission(new Permission.Level(opLevel));
         }
     }
 
@@ -37,7 +40,7 @@ public interface PermissionAccessor {
         }
 
         @Override
-        public boolean hasPermission(ServerCommandSource source, String permission, int opLevel) {
+        public boolean hasPermission(ServerCommandSource source, String permission, @NotNull PermissionLevel opLevel) {
             return Permissions.check(source, permission, opLevel);
         }
     }

--- a/src/main/java/xyz/nucleoid/leukocyte/rule/ProtectionExclusions.java
+++ b/src/main/java/xyz/nucleoid/leukocyte/rule/ProtectionExclusions.java
@@ -3,6 +3,7 @@ package xyz.nucleoid.leukocyte.rule;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import net.minecraft.command.DefaultPermissions;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.PlayerConfigEntry;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -78,7 +79,7 @@ public final class ProtectionExclusions {
     }
 
     public boolean isExcluded(PlayerEntity player) {
-        if (!this.includeOperators && player.hasPermissionLevel(4)) {
+        if (!this.includeOperators && player.getPermissions().hasPermission(DefaultPermissions.OWNERS)) {
             return true;
         }
 


### PR DESCRIPTION
Updates the mod to 1.21.11.

~~Marking this as a draft until NucleoidMC/stimuli#66 is merged.~~

Still using Yarn mappings for now. I was thinking it might be best to update to 1.21.11 first and then make the switch to Mojmap.

The main notable change I made was to change the integer permission level type for PermissionAccessor to the new PermissionLevel enum, taking inspiration from how Fabric Permissions API handled it. Let me know if you'd rather handle it differently or keep a deprecated version with the integer type.